### PR TITLE
cloudsearch: Modify the 'too many results?' links

### DIFF
--- a/lib/modules/cloudsearch.js
+++ b/lib/modules/cloudsearch.js
@@ -31,7 +31,9 @@ addModule('cloudsearch', function(module, moduleID) {
 				var checked="false";
 				var qs = new QueryString();
 				var cs = qs.value("syntax");
+				var cloudsearched = false;
 				if (cs == "cloudsearch") {
+					cloudsearched = true;
 					checked = " checked";
 				}
 
@@ -73,6 +75,14 @@ addModule('cloudsearch', function(module, moduleID) {
 					}
 
 					div.querySelector("input").tabIndex = tabnum + 1;
+				}
+
+				// we need to add the cloudsearch flag to the 'too many results? narrow it down!' links.
+				if (cloudsearched) {
+					var facets = document.querySelectorAll("div.content > div.searchfacets li.searchfacet a.facet");
+					for (var i = 0; i < facets.length; i++) {
+						facets.item(i).href += "&syntax=cloudsearch";
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The links given under "are there too many results? narrow it down to a subreddit!" heading, if they existed, weren't set to use cloudsearch. Whoops!

While we're at it, use a "cloudsearched" flag to specify whether the current search was made using cloudsearch.

This commit mirrors commit Sophira/greasemonkey-scripts@bb05cd9.
